### PR TITLE
Add scale_type parameter to the api

### DIFF
--- a/imageresizer/repository/crud.py
+++ b/imageresizer/repository/crud.py
@@ -3,10 +3,20 @@ Provide CRUD operations for resized images
 """
 import dataclasses
 from datetime import datetime
+from enum import Enum
 
 from sqlalchemy.orm import Session
 
 from imageresizer.repository import models
+
+
+class ScaleType(Enum):
+    """
+    Supported scaling types
+    """
+
+    FIT_XY = 1
+    FIT_PRESERVE_ASPECT_RATIO = 2
 
 
 @dataclasses.dataclass
@@ -19,6 +29,7 @@ class ResizedImageLookup:
     width: int = 0
     height: int = 0
     image_format: str = None
+    scale_type: ScaleType = None
 
 
 def get_resized_image(
@@ -35,6 +46,7 @@ def get_resized_image(
             models.ResizedImage.width == lookup.width,
             models.ResizedImage.height == lookup.height,
             models.ResizedImage.image_format == lookup.image_format,
+            models.ResizedImage.scale_type == lookup.scale_type.value,
         )
         .first()
     )
@@ -51,6 +63,7 @@ def create_resized_image(
         width=lookup.width,
         height=lookup.height,
         image_format=lookup.image_format,
+        scale_type=lookup.scale_type.value,
         file=file,
         datetime=datetime.now(),
     )

--- a/imageresizer/repository/models.py
+++ b/imageresizer/repository/models.py
@@ -17,7 +17,9 @@ class ResizedImage(Base):
     url = Column(String)
     width = Column(Integer)
     height = Column(Integer)
+    # Would be better to have an enum for vaild image_format values
     image_format = Column(String)
+    scale_type = Column(Integer)
     file = Column(String)
     datetime = Column(DateTime)
 
@@ -28,5 +30,6 @@ Index(
     ResizedImage.width,
     ResizedImage.height,
     ResizedImage.image_format,
+    ResizedImage.scale_type,
     unique=True,
 )

--- a/imageresizer/service/mapping.py
+++ b/imageresizer/service/mapping.py
@@ -3,9 +3,18 @@ Image resizing service types
 """
 
 from imageresizer.repository import crud
-from imageresizer.service.types import ResizedImageLookup
+from imageresizer.service.types import ScaleType, ResizedImageLookup
 
 Size = tuple[int, int]
+
+
+def _map_scale_type(service_scale_type: ScaleType) -> crud.ScaleType:
+    """
+    Convert a service ScaleType to a repository ScaleType
+    """
+    if service_scale_type == ScaleType.FIT_XY:
+        return crud.ScaleType.FIT_XY
+    return crud.ScaleType.FIT_PRESERVE_ASPECT_RATIO
 
 
 def map_lookup(service_lookup: ResizedImageLookup) -> crud.ResizedImageLookup:
@@ -19,4 +28,5 @@ def map_lookup(service_lookup: ResizedImageLookup) -> crud.ResizedImageLookup:
         image_format=service_lookup.image_format.name
         if service_lookup.image_format
         else None,
+        scale_type=_map_scale_type(service_lookup.scale_type),
     )

--- a/imageresizer/service/types.py
+++ b/imageresizer/service/types.py
@@ -31,7 +31,17 @@ class ImageFormat(str, Enum):
     WEBP = "webp"
 
 
+class ScaleType(str, Enum):
+    """
+    Supported scale types
+    """
+
+    FIT_XY = "fit_xy"
+    FIT_PRESERVE_ASPECT_RATIO = "fit_preserve_aspect_ratio"
+
+
 @dataclasses.dataclass
+# pylint: disable=duplicate-code
 class ResizedImageLookup:
     """
     Fields which uniquely identify a resised image in the database
@@ -41,3 +51,4 @@ class ResizedImageLookup:
     width: int = 0
     height: int = 0
     image_format: ImageFormat = None
+    scale_type: ScaleType = ScaleType.FIT_XY

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3,97 +3,125 @@ Image resizer tests
 """
 from typing import Optional
 
+import pytest
+
 from imageresizer.service.service import get_resized_size, Size
+from imageresizer.service.types import ScaleType
 
 
 def _test_get_resized_size(
     source_size: Size,
     input_width: Optional[int],
     input_height: Optional[int],
+    input_scale_type: ScaleType,
     expected_output_size: Size,
 ):
     actual_output_size = get_resized_size(
         source_size=source_size,
         request_width=input_width,
         request_height=input_height,
+        scale_type=input_scale_type,
     )
     assert expected_output_size == actual_output_size
 
 
-def test_get_resized_size_no_input():
+@pytest.mark.parametrize("scale_type", ScaleType)
+def test_get_resized_size_no_input(scale_type: ScaleType):
     """
     When no width or height are provided, return the source size
     """
-    _test_get_resized_size((150, 100), None, None, (150, 100))
+    _test_get_resized_size((150, 100), None, None, scale_type, (150, 100))
 
 
-def test_get_resized_size_valid_width_and_height():
+def test_get_resized_size_valid_width_and_height_fit_xy():
     """
-    When a valid width and height are provided, return the provided width and height
+    When a valid width and height are provided with fit_xy scale type,
+    return the provided width and height
     """
-    _test_get_resized_size((150, 100), 25, 75, (25, 75))
+    _test_get_resized_size((150, 100), 25, 75, ScaleType.FIT_XY, (25, 75))
 
 
-def test_get_resized_size_zero_width_and_height():
+def test_get_resized_size_valid_width_and_height_fit_preserve_aspect_ratio():
+    """
+    When a valid width and height are provided with fit_preserve_aspect_ratio scale type,
+    return the expected width and height
+    """
+    _test_get_resized_size(
+        (150, 100), 25, 75, ScaleType.FIT_PRESERVE_ASPECT_RATIO, (25, 16)
+    )
+    _test_get_resized_size(
+        (150, 100), 750, 25, ScaleType.FIT_PRESERVE_ASPECT_RATIO, (37, 25)
+    )
+
+
+@pytest.mark.parametrize("scale_type", ScaleType)
+def test_get_resized_size_zero_width_and_height(scale_type: ScaleType):
     """
     When both width and height are zero, return the source size
     """
-    _test_get_resized_size((150, 100), 0, 0, (150, 100))
+    _test_get_resized_size((150, 100), 0, 0, scale_type, (150, 100))
 
 
-def test_get_resized_size_negative_width_and_height():
+@pytest.mark.parametrize("scale_type", ScaleType)
+def test_get_resized_size_negative_width_and_height(scale_type: ScaleType):
     """
     When both width and height are negative, return the source size
     """
-    _test_get_resized_size((150, 100), -1, -1, (150, 100))
-    _test_get_resized_size((150, 100), -5, -5, (150, 100))
+    _test_get_resized_size((150, 100), -1, -1, scale_type, (150, 100))
+    _test_get_resized_size((150, 100), -5, -5, scale_type, (150, 100))
 
 
-def test_get_missing_width():
+@pytest.mark.parametrize("scale_type", ScaleType)
+def test_get_missing_width(scale_type: ScaleType):
     """
     When the width is missing, return the provided height with the width calculated
     from the aspect ratio of the source and the provided height
     """
-    _test_get_resized_size((150, 100), None, 50, (75, 50))
+    _test_get_resized_size((150, 100), None, 50, scale_type, (75, 50))
 
 
-def test_get_zero_width():
+@pytest.mark.parametrize("scale_type", ScaleType)
+def test_get_zero_width(scale_type: ScaleType):
     """
     When the width is zero, return the provided height with the width calculated
     from the aspect ratio of the source and the provided height
     """
-    _test_get_resized_size((150, 100), 0, 50, (75, 50))
+    _test_get_resized_size((150, 100), 0, 50, scale_type, (75, 50))
 
 
-def test_get_negative_width():
+@pytest.mark.parametrize("scale_type", ScaleType)
+def test_get_negative_width(scale_type: ScaleType):
     """
     When the width is negative, return the provided height with the width calculated
     from the aspect ratio of the source and the provided height
     """
-    _test_get_resized_size((150, 100), -1, 50, (75, 50))
-    _test_get_resized_size((150, 100), -5, 50, (75, 50))
+    _test_get_resized_size((150, 100), -1, 50, scale_type, (75, 50))
+    _test_get_resized_size((150, 100), -5, 50, scale_type, (75, 50))
 
 
-def test_get_missing_height():
+@pytest.mark.parametrize("scale_type", ScaleType)
+def test_get_missing_height(scale_type: ScaleType):
     """
     When the height is missing, return the provided width with the height calculated
     from the aspect ratio of the source and the provided width
     """
-    _test_get_resized_size((150, 100), 75, None, (75, 50))
+    _test_get_resized_size((150, 100), 75, None, scale_type, (75, 50))
 
 
-def test_get_zero_height():
+@pytest.mark.parametrize("scale_type", ScaleType)
+def test_get_zero_height(scale_type: ScaleType):
     """
     When the height is zero, return the provided width with the height calculated
     from the aspect ratio of the source and the provided width
     """
-    _test_get_resized_size((150, 100), 75, 0, (75, 50))
+    _test_get_resized_size((150, 100), 75, 0, scale_type, (75, 50))
 
 
-def test_get_negative_height():
+@pytest.mark.parametrize("scale_type", ScaleType)
+def test_get_negative_height(scale_type: ScaleType):
     """
     When the height is negative, return the provided width with the height calculated
     from the aspect ratio of the source and the provided width
     """
-    _test_get_resized_size((150, 100), 75, -1, (75, 50))
-    _test_get_resized_size((150, 100), 75, -5, (75, 50))
+    _test_get_resized_size((150, 100), 75, -1, scale_type, (75, 50))
+    _test_get_resized_size((150, 100), 75, -5, scale_type, (75, 50))


### PR DESCRIPTION
The following values are supported:
* `fit_xy` (default): the image wtdth and height will be scaled independently to fit the requsted width and height. The aspect ratio may not be prserved.
* `fit_preserve_aspect_ratio`: the image aspect ratio will be preserved, and the resized image will fit within the requested dimensions. the resuling image size may have one dimension which is smaller than the requested dimension.