### PR TITLE
Docker: Schedule cache purge nightly with a crontab command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,17 @@ FROM python:3.10-slim
 
 WORKDIR /app
 
+RUN apt-get update && apt-get --assume-yes install cron
+
 COPY requirements/prod.txt requirements.txt
 
 RUN pip install -r requirements.txt
 
 COPY imageresizer imageresizer
 
-CMD CACHE_DIR=/var/cache/image-resizer python -m imageresizer.main
+CMD cron_comment="purge imageresizer cache" ;\
+    cron_command="cd /app && LOG_FOLDER=${LOG_FOLDER:-.} CACHE_VALIDITY_S=${CACHE_VALIDITY_S:-86400} /usr/local/bin/python -m imageresizer.purge" ; \
+    cron_schedule=${CRON_SCHEDULE:-"20 2 * * *"}; \
+    (crontab -l |grep --invert-match --fixed-strings  "$cron_comment"; echo "$cron_schedule $cron_command #$cron_comment")  | crontab -  && \
+    cron && \
+    CACHE_DIR=/var/cache/image-resizer python -m imageresizer.main

--- a/README.md
+++ b/README.md
@@ -56,11 +56,16 @@ docker run --detach --env WEB_CONCURRENCY=4 --publish 8000:8000 imageresizer
 
 #### Cache clean schedule
 
-By default, when purging the cache, images older than 24 hours are deleted. To change this, set the
-`CACHE_VALIDITY_S` environment variable. For example, to purge images older than one hour:
+By default, when purging the cache, the cache is cleaned nightly at 2:20 am, and images older than 24 hours are deleted.
+To change this:
+
+* set the `CACHE_VALIDITY_S` environment variable for the duration which images should be cached (in seconds).
+* set the `CRON_SCHEDULE` environment variable to specify the schedule for the cleaning task.
+
+For example, to purge images older than one hour, every 2 minutes::
 
 ```bash
-docker run --detach --env CACHE_VALIDITY_S=3600 --publish 8000:8000 imageresizer
+docker run --detach --env CACHE_VALIDITY_S=3600 --env CRON_SCHEDULE="*/2 * * * " --publish 8000:8000 imageresizer
 ```
 
 #### Stopping the containers

--- a/scripts/docker_runserver.bash
+++ b/scripts/docker_runserver.bash
@@ -15,4 +15,5 @@ docker run \
     --env WEB_CONCURRENCY=4 \
     --env LOG_FOLDER=$container_log_dir \
     --env CACHE_VALIDITY_S=3600 \
+    --env CRON_SCHEDULE="* * * * *" \
     imageresizer


### PR DESCRIPTION
The changes in this PR only impact the application running in a Docker container.

The `Dockerfile` adds a cron entry to periodically delete old images.

Environment variables can be passed to `docker run` to control the behavior:
* `CACHE_VALIDITY_S`: specifies the validity in seconds of an image. Images older than this will be deleted.
* `CRON_SCHEDULE`: a cron schedule string to determine the frequency at which the db clean task will be run.

Alternate PR: #10