### PR TITLE
Schedule periodic db purges using a Timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,18 @@ docker run --detach --env WEB_CONCURRENCY=4 --publish 8000:8000 imageresizer
 
 #### Cache clean schedule
 
-By default, when purging the cache, images older than 24 hours are deleted. To change this, set the
-`CACHE_VALIDITY_S` environment variable. For example, to purge images older than one hour:
+By default, when purging the cache, the cache is cleaned every 24 hours starting from server launch, and images
+older than 24 hours are deleted.
+
+To change this:
+
+* set the `CACHE_VALIDITY_S` environment variable for the duration which images should be cached (in seconds).
+* set the `CACHE_CLEAN_INTERVAL_S` environment variable to specify the interval in seconds between cleaning tasks.
+
+For example, to purge images older than one hour, every 2 minutes::
 
 ```bash
-docker run --detach --env CACHE_VALIDITY_S=3600 --publish 8000:8000 imageresizer
+docker run --detach --env CACHE_VALIDITY_S=3600 --env CACHE_CLEAN_INTERVAL_S=120 --publish 8000:8000 imageresizer
 ```
 
 #### Stopping the containers

--- a/imageresizer/main.py
+++ b/imageresizer/main.py
@@ -8,7 +8,6 @@ from fastapi import FastAPI
 
 from imageresizer import purge
 from imageresizer.repository import models
-from imageresizer.repository.database import SessionLocal
 from imageresizer.routers import resize
 from imageresizer.settings import settings
 
@@ -30,8 +29,7 @@ def setup():
     Prepare for the app to run
     """
     models.create_db()
-    with SessionLocal() as session:
-        purge.purge_old_images(session)
+    purge.schedule()
 
 
 if __name__ == "__main__":

--- a/imageresizer/purge.py
+++ b/imageresizer/purge.py
@@ -6,12 +6,24 @@ import datetime
 import logging
 import os
 from os.path import exists
+from threading import Timer
 
 from sqlalchemy.orm import Session
 
 from imageresizer.repository import models
 from imageresizer.repository.database import SessionLocal
 from imageresizer.settings import settings
+
+
+def schedule():
+    """
+    Schedule a periodic purge of the image cache
+    """
+    with SessionLocal() as session:
+        purge_old_images(session)
+    timer = Timer(settings.cache_clean_interval_s, schedule)
+    timer.daemon = True
+    timer.start()
 
 
 def purge_old_images(session: Session, max_age_seconds: int = None):

--- a/imageresizer/settings.py
+++ b/imageresizer/settings.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     log_folder: str = "."
     cache_dir: str = None
     cache_validity_s = 86400
+    cache_clean_interval_s = 86400
 
     def _create_log_folder(self):
         Path(self.log_folder).mkdir(parents=True, exist_ok=True)

--- a/scripts/docker_runserver.bash
+++ b/scripts/docker_runserver.bash
@@ -15,4 +15,5 @@ docker run \
     --env WEB_CONCURRENCY=4 \
     --env LOG_FOLDER=$container_log_dir \
     --env CACHE_VALIDITY_S=3600 \
+    --env CACHE_CLEAN_INTERVAL_S=30 \
     imageresizer


### PR DESCRIPTION
The changes to this PR impact the application regardless of whether it's run in a Docker container.

When the application is launched, it starts a periodic task which deletes old images from the database. 

Environment variables can be set to control the behavior:

* `CACHE_VALIDITY_S`: specifies the validity in seconds of an image. Images older than this will be deleted.
* `CACHE_CLEAN_INTERVAL_S`: specifies the interval between cleaning tasks. Note that the timer is scheduled at fixed-delay, not at fixed-rate. The interval is between the end of one cleaning task and the beginning of the next. Some drift will accumulate over time.

Alternate PR: #8 