### PR TITLE
Update documentation and fix some parameter issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ RUN pip install -r requirements.txt
 
 COPY imageresizer imageresizer
 
-CMD CACHE_DIR=/var/cache/image-resizer python -m imageresizer.main
+CMD CACHE_DIR=/var/cache/image-resizer LOG_DIR=/var/log/image-resizer python -m imageresizer.main

--- a/imageresizer/main.py
+++ b/imageresizer/main.py
@@ -2,6 +2,7 @@
 Server that provides an endpoint to resize an image
 """
 import logging
+import os
 
 import uvicorn
 from fastapi import FastAPI
@@ -37,5 +38,5 @@ if __name__ == "__main__":
     uvicorn.run(
         "imageresizer.main:app",
         host="0.0.0.0",
-        port=8000,
+        port=int(os.environ.get("UVICORN_PORT", "8000")),
     )

--- a/imageresizer/repository/database.py
+++ b/imageresizer/repository/database.py
@@ -7,8 +7,7 @@ from sqlalchemy.orm import sessionmaker
 
 from imageresizer.settings import settings
 
-DB_DIR = settings.cache_dir if settings.cache_image_dir else "."
-SQLALCHEMY_DATABASE_URL = f"sqlite:///{DB_DIR}/image-resizer.db"
+SQLALCHEMY_DATABASE_URL = f"sqlite:///{settings.cache_dir}/image-resizer.db"
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
 )

--- a/imageresizer/settings.py
+++ b/imageresizer/settings.py
@@ -12,27 +12,27 @@ class Settings(BaseSettings):
     Settings for the app
     """
 
-    log_folder: str = "."
-    cache_dir: str = None
+    log_dir: str = "."
+    cache_dir: str = "."
     cache_validity_s = 86400
     cache_clean_interval_s = 86400
 
-    def _create_log_folder(self):
-        Path(self.log_folder).mkdir(parents=True, exist_ok=True)
+    def _create_log_dir(self):
+        Path(self.log_dir).mkdir(parents=True, exist_ok=True)
 
     def get_log_absolute_path(self, filename) -> str:
         """
         :return: the path to the log file with the given name
         """
-        self._create_log_folder()
-        return str(Path(self.log_folder) / filename)
+        self._create_log_dir()
+        return str(Path(self.log_dir) / filename)
 
     @property
     def cache_image_dir(self) -> str:
         """
         :return: the path where image files will be stored
         """
-        return str(Path(self.cache_dir) / "images") if self.cache_dir else None
+        return str(Path(self.cache_dir) / "images")
 
 
 settings = Settings()

--- a/scripts/docker_remove_containers.bash
+++ b/scripts/docker_remove_containers.bash
@@ -5,3 +5,10 @@ do
   docker rm $container
 done 
 
+for container in $(docker ps --all --filter ancestor=ghcr.io/caarmen/image-resizer --format="{{.ID}}")
+do
+  echo "stopping container $container"
+  docker stop $container
+  docker rm $container
+done
+

--- a/scripts/docker_runserver.bash
+++ b/scripts/docker_runserver.bash
@@ -5,15 +5,12 @@ host_log_dir=/tmp/image-resizer/logs
 mkdir -p $host_cache_dir
 mkdir -p $host_log_dir
 
-container_log_dir=/var/log/image_resizer
-
 docker run \
     --volume $host_cache_dir:/var/cache/image-resizer \
-    --volume $host_log_dir:$container_log_dir \
+    --volume $host_log_dir:/var/log/image-resizer \
     --detach \
     --publish 8000:8000 \
     --env WEB_CONCURRENCY=4 \
-    --env LOG_FOLDER=$container_log_dir \
     --env CACHE_VALIDITY_S=3600 \
     --env CACHE_CLEAN_INTERVAL_S=30 \
     imageresizer


### PR DESCRIPTION
Parameters corrections:
* Use consistent naming and default values for `LOG_DIR` and `CACHE_DIR` environment variables
* Make `docker_remove_containers.bash` delete image resizer Docker containers built locally or downloaded from Github packages
* Read `UVICORN_PORT` environment variable for specifying the port

Documentation:
* Add quick start to be able to download the docker image without cloning this repo
* Update documentation to specify how to use environment variables when running the server locally