### PR TITLE
Issue #15: Add crop scale type

### DIFF
--- a/imageresizer/repository/crud.py
+++ b/imageresizer/repository/crud.py
@@ -31,6 +31,7 @@ class ScaleType(Enum):
 
     FIT_XY = 1
     FIT_PRESERVE_ASPECT_RATIO = 2
+    CROP = 3
 
 
 @dataclasses.dataclass

--- a/imageresizer/service/animatedimage.py
+++ b/imageresizer/service/animatedimage.py
@@ -17,16 +17,17 @@ class AnimatedImage:
         self._source = source
         self._frames = []
 
-    def resize(self, size: Size):
+    def resize(self, size: Size, box: tuple | None):
         """
         Resize the frames of this image
         :param size: The requested size in pixels
+        :param box: The region in the source image to resize
         :return: this instance
         """
         for i in range(self._source.n_frames):
             self._source.seek(i)
             self._frames.append(
-                self._source.resize(size, resample=Image.Resampling.BICUBIC)
+                self._source.resize(size, box=box, resample=Image.Resampling.BICUBIC)
             )
         return self
 

--- a/imageresizer/service/geometry.py
+++ b/imageresizer/service/geometry.py
@@ -1,6 +1,7 @@
 """
 Geometric calculations for resizing images
 """
+import dataclasses
 from typing import Optional
 
 from imageresizer.service.types import ScaleType
@@ -8,56 +9,86 @@ from imageresizer.service.types import ScaleType
 Size = tuple[int, int]
 
 
+@dataclasses.dataclass
+class Box:
+    """
+    Defines a zone inside an image
+    """
+
+    left: int
+    top: int
+    right: int
+    bottom: int
+
+
+@dataclasses.dataclass
+class ResizeGeometry:
+    """
+    Determines how an image should be resized
+    """
+
+    size: Size
+    box: Box = None
+
+
 def _is_valid_dimension(dimension):
     return dimension is not None and dimension > 0
 
 
-def _get_resized_size_partial_requested_size(
+def _get_resize_geometry_partial_requested_size(
     source_size: Size,
     request_width: Optional[int],
     request_height: Optional[int],
-) -> Size:
+) -> ResizeGeometry:
     # No dimensions requested: return the original size
     if not request_width and not request_height:
-        return source_size
+        return ResizeGeometry(size=source_size)
 
     # Only one dimension requested: calculate the other one from
     # the original aspect ratio and the one dimension which is provided
     source_aspect_ratio = source_size[0] / source_size[1]
     if request_width and not request_height:
-        return request_width, int(request_width / source_aspect_ratio)
+        return ResizeGeometry(
+            size=(request_width, int(request_width / source_aspect_ratio))
+        )
     # not request_width and request_height:
-    return int(request_height * source_aspect_ratio), request_height
+    return ResizeGeometry(
+        size=(int(request_height * source_aspect_ratio), request_height)
+    )
 
 
-def _get_resized_size_fit_xy(
+def _get_resize_geometry_fit_xy(
     _: Size,
     request_width: Optional[int],
     request_height: Optional[int],
-) -> Size:
-    return request_width, request_height
+) -> ResizeGeometry:
+    return ResizeGeometry(size=(request_width, request_height))
 
 
-def _get_resized_size_fit_preserve_aspect_ratio(
+def _get_resize_geometry_fit_preserve_aspect_ratio(
     source_size: Size,
     request_width: Optional[int],
     request_height: Optional[int],
-) -> Size:
+) -> ResizeGeometry:
     source_aspect_ratio = source_size[0] / source_size[1]
     # Else fit the image inside the bounds of the requested dimensions,
     # preserving the original aspect ratio
     dest_aspect_ratio = request_width / request_height
     if source_aspect_ratio > dest_aspect_ratio:
-        return request_width, int(request_width / source_aspect_ratio)
-    return int(request_height * source_aspect_ratio), request_height
+        return ResizeGeometry(
+            size=(request_width, int(request_width / source_aspect_ratio))
+        )
+    return ResizeGeometry(
+        size=(int(request_height * source_aspect_ratio), request_height)
+    )
 
 
-def get_resized_size(
+def get_resize_geometry(
     source_size: Size,
     request_width: Optional[int],
     request_height: Optional[int],
     scale_type: ScaleType,
-) -> Size:
+) -> ResizeGeometry:
     """
     Calculate a new resized size based on a source size and optional new width and height.
 
@@ -77,7 +108,7 @@ def get_resized_size(
     valid_width = _is_valid_dimension(request_width)
     valid_height = _is_valid_dimension(request_height)
     if not valid_width or not valid_height:
-        return _get_resized_size_partial_requested_size(
+        return _get_resize_geometry_partial_requested_size(
             source_size=source_size,
             request_width=request_width if valid_width else None,
             request_height=request_height if valid_height else None,
@@ -86,8 +117,10 @@ def get_resized_size(
     # Both dimensions provided
     match scale_type:
         case ScaleType.FIT_XY:
-            return _get_resized_size_fit_xy(source_size, request_width, request_height)
+            return _get_resize_geometry_fit_xy(
+                source_size, request_width, request_height
+            )
         case _:  # ScaleType.FIT_PRESERVE_ASPECT_RATIO:
-            return _get_resized_size_fit_preserve_aspect_ratio(
+            return _get_resize_geometry_fit_preserve_aspect_ratio(
                 source_size, request_width, request_height
             )

--- a/imageresizer/service/mapping.py
+++ b/imageresizer/service/mapping.py
@@ -42,6 +42,8 @@ def _map_scale_type(service_scale_type: ScaleType) -> crud.ScaleType:
     match service_scale_type:
         case ScaleType.FIT_XY:
             return crud.ScaleType.FIT_XY
+        case ScaleType.CROP:
+            return crud.ScaleType.CROP
         case _:
             return crud.ScaleType.FIT_PRESERVE_ASPECT_RATIO
 

--- a/imageresizer/service/types.py
+++ b/imageresizer/service/types.py
@@ -36,6 +36,7 @@ class ScaleType(str, Enum):
 
     FIT_XY = "fit_xy"
     FIT_PRESERVE_ASPECT_RATIO = "fit_preserve_aspect_ratio"
+    CROP = "crop"
 
 
 @dataclasses.dataclass

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -66,6 +66,34 @@ def test_get_resize_geometry_valid_width_and_height_fit_preserve_aspect_ratio():
     )
 
 
+def test_get_resize_geometry_valid_width_and_height_crop():
+    """
+    When a valid width and height are provided with crop scale_type,
+    return the expected width and height
+    """
+    _test_get_resize_geometry(
+        (150, 100),
+        25,
+        75,
+        ScaleType.CROP,
+        ResizeGeometry(size=(25, 75), box=Box(left=58, top=0, right=91, bottom=100)),
+    )
+    _test_get_resize_geometry(
+        (150, 100),
+        750,
+        25,
+        ScaleType.CROP,
+        ResizeGeometry(size=(750, 25), box=Box(left=0, top=47, right=150, bottom=52)),
+    )
+    _test_get_resize_geometry(
+        (560, 560),
+        50,
+        100,
+        ScaleType.CROP,
+        ResizeGeometry(size=(50, 100), box=Box(left=140, top=0, right=420, bottom=560)),
+    )
+
+
 @pytest.mark.parametrize("scale_type", ScaleType)
 def test_get_resize_geometry_zero_width_and_height(scale_type: ScaleType):
     """

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -5,70 +5,88 @@ from typing import Optional
 
 import pytest
 
-from imageresizer.service.geometry import get_resized_size, Size
+from imageresizer.service.geometry import ResizeGeometry, get_resize_geometry, Size, Box
 from imageresizer.service.types import ScaleType
 
 
-def _test_get_resized_size(
+def _test_get_resize_geometry(
     source_size: Size,
     input_width: Optional[int],
     input_height: Optional[int],
     input_scale_type: ScaleType,
-    expected_output_size: Size,
+    expected_output_resize_geometry: ResizeGeometry,
 ):
-    actual_output_size = get_resized_size(
+    actual_output_resize_geometry = get_resize_geometry(
         source_size=source_size,
         request_width=input_width,
         request_height=input_height,
         scale_type=input_scale_type,
     )
-    assert actual_output_size == expected_output_size
+    assert actual_output_resize_geometry == expected_output_resize_geometry
 
 
 @pytest.mark.parametrize("scale_type", ScaleType)
-def test_get_resized_size_no_input(scale_type: ScaleType):
+def test_get_resize_geometry_no_input(scale_type: ScaleType):
     """
     When no width or height are provided, return the source size
     """
-    _test_get_resized_size((150, 100), None, None, scale_type, (150, 100))
+    _test_get_resize_geometry(
+        (150, 100), None, None, scale_type, ResizeGeometry(size=(150, 100))
+    )
 
 
-def test_get_resized_size_valid_width_and_height_fit_xy():
+def test_get_resize_geometry_valid_width_and_height_fit_xy():
     """
     When a valid width and height are provided with fit_xy scale type,
     return the provided width and height
     """
-    _test_get_resized_size((150, 100), 25, 75, ScaleType.FIT_XY, (25, 75))
+    _test_get_resize_geometry(
+        (150, 100), 25, 75, ScaleType.FIT_XY, ResizeGeometry(size=(25, 75))
+    )
 
 
-def test_get_resized_size_valid_width_and_height_fit_preserve_aspect_ratio():
+def test_get_resize_geometry_valid_width_and_height_fit_preserve_aspect_ratio():
     """
     When a valid width and height are provided with fit_preserve_aspect_ratio scale type,
     return the expected width and height
     """
-    _test_get_resized_size(
-        (150, 100), 25, 75, ScaleType.FIT_PRESERVE_ASPECT_RATIO, (25, 16)
+    _test_get_resize_geometry(
+        (150, 100),
+        25,
+        75,
+        ScaleType.FIT_PRESERVE_ASPECT_RATIO,
+        ResizeGeometry(size=(25, 16)),
     )
-    _test_get_resized_size(
-        (150, 100), 750, 25, ScaleType.FIT_PRESERVE_ASPECT_RATIO, (37, 25)
+    _test_get_resize_geometry(
+        (150, 100),
+        750,
+        25,
+        ScaleType.FIT_PRESERVE_ASPECT_RATIO,
+        ResizeGeometry(size=(37, 25)),
     )
 
 
 @pytest.mark.parametrize("scale_type", ScaleType)
-def test_get_resized_size_zero_width_and_height(scale_type: ScaleType):
+def test_get_resize_geometry_zero_width_and_height(scale_type: ScaleType):
     """
     When both width and height are zero, return the source size
     """
-    _test_get_resized_size((150, 100), 0, 0, scale_type, (150, 100))
+    _test_get_resize_geometry(
+        (150, 100), 0, 0, scale_type, ResizeGeometry(size=(150, 100))
+    )
 
 
 @pytest.mark.parametrize("scale_type", ScaleType)
-def test_get_resized_size_negative_width_and_height(scale_type: ScaleType):
+def test_get_resize_geometry_negative_width_and_height(scale_type: ScaleType):
     """
     When both width and height are negative, return the source size
     """
-    _test_get_resized_size((150, 100), -1, -1, scale_type, (150, 100))
-    _test_get_resized_size((150, 100), -5, -5, scale_type, (150, 100))
+    _test_get_resize_geometry(
+        (150, 100), -1, -1, scale_type, ResizeGeometry(size=(150, 100))
+    )
+    _test_get_resize_geometry(
+        (150, 100), -5, -5, scale_type, ResizeGeometry(size=(150, 100))
+    )
 
 
 @pytest.mark.parametrize("scale_type", ScaleType)
@@ -77,7 +95,9 @@ def test_get_missing_width(scale_type: ScaleType):
     When the width is missing, return the provided height with the width calculated
     from the aspect ratio of the source and the provided height
     """
-    _test_get_resized_size((150, 100), None, 50, scale_type, (75, 50))
+    _test_get_resize_geometry(
+        (150, 100), None, 50, scale_type, ResizeGeometry(size=(75, 50))
+    )
 
 
 @pytest.mark.parametrize("scale_type", ScaleType)
@@ -86,7 +106,9 @@ def test_get_zero_width(scale_type: ScaleType):
     When the width is zero, return the provided height with the width calculated
     from the aspect ratio of the source and the provided height
     """
-    _test_get_resized_size((150, 100), 0, 50, scale_type, (75, 50))
+    _test_get_resize_geometry(
+        (150, 100), 0, 50, scale_type, ResizeGeometry(size=(75, 50))
+    )
 
 
 @pytest.mark.parametrize("scale_type", ScaleType)
@@ -95,8 +117,12 @@ def test_get_negative_width(scale_type: ScaleType):
     When the width is negative, return the provided height with the width calculated
     from the aspect ratio of the source and the provided height
     """
-    _test_get_resized_size((150, 100), -1, 50, scale_type, (75, 50))
-    _test_get_resized_size((150, 100), -5, 50, scale_type, (75, 50))
+    _test_get_resize_geometry(
+        (150, 100), -1, 50, scale_type, ResizeGeometry(size=(75, 50))
+    )
+    _test_get_resize_geometry(
+        (150, 100), -5, 50, scale_type, ResizeGeometry(size=(75, 50))
+    )
 
 
 @pytest.mark.parametrize("scale_type", ScaleType)
@@ -105,7 +131,9 @@ def test_get_missing_height(scale_type: ScaleType):
     When the height is missing, return the provided width with the height calculated
     from the aspect ratio of the source and the provided width
     """
-    _test_get_resized_size((150, 100), 75, None, scale_type, (75, 50))
+    _test_get_resize_geometry(
+        (150, 100), 75, None, scale_type, ResizeGeometry(size=(75, 50))
+    )
 
 
 @pytest.mark.parametrize("scale_type", ScaleType)
@@ -114,7 +142,9 @@ def test_get_zero_height(scale_type: ScaleType):
     When the height is zero, return the provided width with the height calculated
     from the aspect ratio of the source and the provided width
     """
-    _test_get_resized_size((150, 100), 75, 0, scale_type, (75, 50))
+    _test_get_resize_geometry(
+        (150, 100), 75, 0, scale_type, ResizeGeometry(size=(75, 50))
+    )
 
 
 @pytest.mark.parametrize("scale_type", ScaleType)
@@ -123,5 +153,9 @@ def test_get_negative_height(scale_type: ScaleType):
     When the height is negative, return the provided width with the height calculated
     from the aspect ratio of the source and the provided width
     """
-    _test_get_resized_size((150, 100), 75, -1, scale_type, (75, 50))
-    _test_get_resized_size((150, 100), 75, -5, scale_type, (75, 50))
+    _test_get_resize_geometry(
+        (150, 100), 75, -1, scale_type, ResizeGeometry(size=(75, 50))
+    )
+    _test_get_resize_geometry(
+        (150, 100), 75, -5, scale_type, ResizeGeometry(size=(75, 50))
+    )


### PR DESCRIPTION
* Step 1: Return a `ResizeGeometry` instead of a `Size` in geometry functions. The `ResizeGeometry` data class contains a `Size` and a `Box`. 
* Step 2: Add support for a crop scale type

#15